### PR TITLE
Moving necessary files to folders

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,14 @@
   "scripts": {
     "dev": "vite",
     "build": "run-p type-check build-only",
+    "postbuild": "node ./postbuild.js",
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "mkdirp": "^3.0.1",
+    "rimraf": "4",
     "vue": "^3.2.45"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "type-check": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "fs-extra": "^11.1.1",
     "mkdirp": "^3.0.1",
     "rimraf": "4",
     "vue": "^3.2.45"

--- a/postbuild.js
+++ b/postbuild.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const mkdirp = require('mkdirp');
 const { moveRemoveSync } = require('rimraf');
@@ -19,25 +19,28 @@ files.filter(fileOrFolder => fileOrFolder.endsWith('.html')).forEach(file => {
   const data = fs.readFileSync(htmlFilePath, 'utf8');
 
   // Find script tags matching the pattern
-  const newData = data.replace(/<link\s+(?:[^>]+\s+)?href="\/(js\/common|assets)\/([^"]+)"/g, (all, typeMatch, match) => {
-    const type = typeMatch === 'js/common' ? 'js' : 'css';
-
+  const newData = data.replace(/<link\s+(?:[^>]+\s+)?href="(\/js\/common\/|\/assets\/)([^"]+)"/g, (all, folder, match) => {
     const jsOrCssFileName = match;
-    const jsFilePath = path.join(jsDirectory, 'common', jsOrCssFileName);
-    const cssFilePath = path.join(cssDirectory, jsOrCssFileName);
-
+    console.log('moving ', folder, match);
+    
+    const filePath = path.join(htmlDirectory, folder, jsOrCssFileName);
     // Copy JS file to the new directory
-    const targetFilePath = path.join(targetFolder, jsOrCssFileName);
+    const targetFilePath = path.join(targetFolder, folder, jsOrCssFileName);
+    const targetFolderPath = path.join(targetFolder, folder);
+
     mkdirp.sync(targetFolder); // Create target folder if it doesn't exist
-    fs.copyFileSync(type === 'js' ? jsFilePath : cssFilePath, targetFilePath);
-    return all.replace(/href="\/(js\/common|assets)\/([^"]+)"/, 'href="$2"');
+    
+    fs.ensureDirSync(targetFolderPath);
+    fs.copyFileSync(filePath, targetFilePath);
+    
+    return all.replace(/href="\/(js\/common|assets)\/([^"]+)"/, 'href="$1/$2"');
   })
-    .replace(/<script\s+(?:[^>]+\s+)?src="\/js\/([^"]+)"/g, (all) => all.replace(/src="\/js\/([^"]+)"/, 'src="$1"'))
+    .replace(/<script\s+(?:[^>]+\s+)?src="\/js\/([^"]+)"/g, (all) => all.replace(/src="\/(js\/[^"]+)"/, 'src="$1"'))
     .replace('<head>', `<head><base href="/${file.replace('.html', '')}/">`);
 
   const jsEntryFile = path.join(jsDirectory, file.replace('.html', '.js'));
 
-  fs.copyFileSync(jsEntryFile, path.join(targetFolder, file.replace('.html', '.js')));
+  fs.copyFileSync(jsEntryFile, path.join(targetFolder, 'js', file.replace('.html', '.js')));
 
   // move html to target folder
   const targetHtmlFilePath = path.join(targetFolder, 'index.html');

--- a/postbuild.js
+++ b/postbuild.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
+const { moveRemoveSync } = require('rimraf');
+
+const htmlDirectory = __dirname + '/dist'; // Replace with the actual directory containing your HTML files
+const jsDirectory = __dirname + '/dist/js'; // Replace with the actual directory containing your JS files
+const cssDirectory = __dirname + '/dist/assets'; // Replace with the actual directory containing your JS files
+
+// Read HTML files in the directory
+const files = fs.readdirSync(htmlDirectory);
+
+// Process each HTML file
+files.filter(fileOrFolder => fileOrFolder.endsWith('.html')).forEach(file => {
+  const htmlFilePath = path.join(htmlDirectory, file);
+  const targetFolder = path.join(htmlDirectory, file.replace('.html', ''));
+
+  // Read HTML file
+  const data = fs.readFileSync(htmlFilePath, 'utf8');
+
+  // Find script tags matching the pattern
+  const newData = data.replace(/<link\s+(?:[^>]+\s+)?href="\/(js\/common|assets)\/([^"]+)"/g, (all, typeMatch, match) => {
+    const type = typeMatch === 'js/common' ? 'js' : 'css';
+
+    const jsOrCssFileName = match;
+    const jsFilePath = path.join(jsDirectory, 'common', jsOrCssFileName);
+    const cssFilePath = path.join(cssDirectory, jsOrCssFileName);
+
+    // Copy JS file to the new directory
+    const targetFilePath = path.join(targetFolder, jsOrCssFileName);
+    mkdirp.sync(targetFolder); // Create target folder if it doesn't exist
+    fs.copyFileSync(type === 'js' ? jsFilePath : cssFilePath, targetFilePath);
+    return all.replace(/href="\/(js\/common|assets)\/([^"]+)"/, 'href="$2"');
+  })
+    .replace(/<script\s+(?:[^>]+\s+)?src="\/js\/([^"]+)"/g, (all) => all.replace(/src="\/js\/([^"]+)"/, 'src="$1"'))
+    .replace('<head>', `<head><base href="/${file.replace('.html', '')}/">`);
+
+  const jsEntryFile = path.join(jsDirectory, file.replace('.html', '.js'));
+
+  fs.copyFileSync(jsEntryFile, path.join(targetFolder, file.replace('.html', '.js')));
+
+  // move html to target folder
+  const targetHtmlFilePath = path.join(targetFolder, 'index.html');
+  
+  fs.writeFileSync(htmlFilePath, newData);
+  
+  fs.copyFileSync(htmlFilePath, targetHtmlFilePath);
+  
+  fs.unlinkSync(htmlFilePath);
+
+
+});
+
+console.log('done post processing');
+
+console.log('cleaning files');
+// delete htmlFilePath / js folder
+moveRemoveSync(jsDirectory);
+
+// delete htmlFilePath / js folder
+moveRemoveSync(cssDirectory);
+console.log('done');


### PR DESCRIPTION
You see I have 2 commits, in the first commit I tried moving files without the folder structure, but it does not work because app1.js has reference to other chunks.
With the second commit we are basically cloning and moving necessary files into 3 folders and using `<base>` tag to serve them like resources are in the root path.

So this setup is for serving those apps by serving the dist folder, if you want to individually serve the folder you would need to remove `<base>` tag.